### PR TITLE
Fix bug in CertEditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CertEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CertEditCommand.java
@@ -80,7 +80,11 @@ public class CertEditCommand extends Command {
             throw new CommandException(MESSAGE_MISSING_CERT);
         }
 
-        Certificate updatedCert = this.getUpdatedCert();
+        // get the actual certificate-to-edit
+        Certificate actualToEdit = personToEdit.getCertificates()
+                .get(personToEdit.getCertIndex(toEdit));
+
+        Certificate updatedCert = this.getUpdatedCert(actualToEdit);
 
         if (newName.isPresent() && personToEdit.hasCert(updatedCert)) {
             throw new CommandException(MESSAGE_DUPLICATE_CERT);
@@ -98,10 +102,9 @@ public class CertEditCommand extends Command {
      * If new values are not supplied, the old values will be reused.
      * @return Certificate with the edited information.
      */
-    private Certificate getUpdatedCert() {
-        CertName updatedName = this.newName.orElse(this.toEdit.getName());
-        CertExpiry updatedExpiry = this.newDate.orElse(this.toEdit.getExpiry());
-
+    private Certificate getUpdatedCert(Certificate actualToEdit) {
+        CertName updatedName = this.newName.orElse(actualToEdit.getName());
+        CertExpiry updatedExpiry = this.newDate.orElse(actualToEdit.getExpiry());
         Certificate updatedCert = new Certificate(updatedName, updatedExpiry);
         return updatedCert;
     }


### PR DESCRIPTION
Inputs of the format cert-edit INDEX n/NAME ne/NEW NAME will wrongfully reset the certificate expiry date to 9999-12-31, a dummy value for certs with no expiry date.

This was because the expiry date was extracted from a placeholder certificate. The fix will find the actual certificate held by the person now and extract the expiry date from that instead.

Fix #133