### PR TITLE
Require `ee/` and/or `ne/` flag for `cert-edit`

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CertEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CertEditCommandParser.java
@@ -36,6 +36,8 @@ public class CertEditCommandParser {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_CERT_NAME, PREFIX_CERT_EXPIRY,
                 PREFIX_CERT_EDIT_NAME, PREFIX_CERT_EDIT_DATE);
+        argMultimap.verifyAtLeastOnePrefixFor(PREFIX_CERT_NAME);
+        argMultimap.verifyAtLeastOnePrefixFor(PREFIX_CERT_EDIT_NAME, PREFIX_CERT_EDIT_DATE);
 
         Index index;
         try {


### PR DESCRIPTION
Fix #179
