### PR TITLE
Fix bug in cert commands and tag

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CertAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CertAddCommand.java
@@ -71,7 +71,7 @@ public class CertAddCommand extends Command {
 
         Person personAddedTo = addCertToPerson(personToAddTo, toAdd);
 
-        model.setPerson(personToAddTo, personAddedTo);
+        model.setPerson(index.getZeroBased(), personAddedTo);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personAddedTo)));
     }

--- a/src/main/java/seedu/address/logic/commands/CertDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CertDeleteCommand.java
@@ -70,7 +70,7 @@ public class CertDeleteCommand extends Command {
 
         Person personDeletedFrom = deleteCertFromPerson(personToDeleteFrom, toDel);
 
-        model.setPerson(personToDeleteFrom, personDeletedFrom);
+        model.setPerson(index.getZeroBased(), personDeletedFrom);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personDeletedFrom)));
     }

--- a/src/main/java/seedu/address/logic/commands/CertEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CertEditCommand.java
@@ -89,7 +89,7 @@ public class CertEditCommand extends Command {
 
         Person personEdited = editCertForPerson(personToEdit, toEdit, updatedCert);
 
-        model.setPerson(personToEdit, personEdited);
+        model.setPerson(index.getZeroBased(), personEdited);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personEdited)));
     }

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -94,7 +94,7 @@ public class TagCommand extends Command {
         }
         model.commitAddressBook();
 
-        model.setPerson(personToEdit, editedPerson);
+        model.setPerson(targetIndex.getZeroBased(), editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(String.format(MESSAGE_TAG_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));

--- a/src/test/java/seedu/address/logic/commands/CertAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CertAddCommandTest.java
@@ -78,6 +78,32 @@ public class CertAddCommandTest {
     }
 
     @Test
+    public void execute_addToIndexSpecifiedPerson() throws Exception {
+        Model model = new ModelManager(new AddressBook(), new UserPrefs());
+
+        // create persons with same name
+        Person person1 = new PersonBuilder().withName("a").build();
+        Person person2 = new PersonBuilder().withName("A").build();
+        new AddCommand(person1).execute(model);
+        new AddCommand(person2).execute(model);
+
+        // add certificate to person 2, not person 1
+        new CertAddCommand(Index.fromOneBased(2), new Certificate(new CertName("OSCP")))
+                .execute(model);
+
+        assertEquals(model.getFilteredPersonList().get(0), person1);
+        ArrayList<Certificate> expectedCertList = new ArrayList<Certificate>() {
+            {
+                add(new Certificate(new CertName("OSCP")));
+            }
+        };
+        Person expectedPerson2 = new PersonBuilder().withName("A")
+                .withCertificates(expectedCertList)
+                .build();
+        assertEquals(model.getFilteredPersonList().get(1), expectedPerson2);
+    }
+
+    @Test
     public void equals() {
         Certificate cert1 = new Certificate(new CertName("cert1"));
         Certificate cert2 = new Certificate(new CertName("cert2"));

--- a/src/test/java/seedu/address/logic/commands/CertDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CertDeleteCommandTest.java
@@ -94,6 +94,33 @@ public class CertDeleteCommandTest {
     }
 
     @Test
+    public void execute_deleteFromIndexSpecifiedPerson() throws Exception {
+        Model model = new ModelManager(new AddressBook(), new UserPrefs());
+
+        // create persons with same name
+        ArrayList<Certificate> certList = new ArrayList<Certificate>() {
+            {
+                add(new Certificate(new CertName("OSCP")));
+            }
+        };
+        Person person1 = new PersonBuilder().withName("a").withCertificates(certList).build();
+        Person person2 = new PersonBuilder().withName("A").withCertificates(certList).build();
+        new AddCommand(person1).execute(model);
+        new AddCommand(person2).execute(model);
+
+        // delete certificate from person 2, not person 1
+        new CertDeleteCommand(Index.fromOneBased(2), new Certificate(new CertName("OSCP")))
+                .execute(model);
+
+        assertEquals(model.getFilteredPersonList().get(0), person1);
+        ArrayList<Certificate> expectedCertList = new ArrayList<Certificate>();
+        Person expectedPerson2 = new PersonBuilder().withName("A")
+                .withCertificates(expectedCertList)
+                .build();
+        assertEquals(model.getFilteredPersonList().get(1), expectedPerson2);
+    }
+
+    @Test
     public void equals() {
         Certificate cert1 = new Certificate(new CertName("cert1"));
         Certificate cert2 = new Certificate(new CertName("cert2"));

--- a/src/test/java/seedu/address/logic/commands/CertEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CertEditCommandTest.java
@@ -169,6 +169,40 @@ public class CertEditCommandTest {
     }
 
     @Test
+    public void execute_editIndexSpecifiedPerson() throws Exception {
+        Model model = new ModelManager(new AddressBook(), new UserPrefs());
+
+        // create persons with same name
+        ArrayList<Certificate> certList = new ArrayList<Certificate>() {
+            {
+                add(new Certificate(new CertName("OSCP")));
+            }
+        };
+        Person person1 = new PersonBuilder().withName("a").withCertificates(certList).build();
+        Person person2 = new PersonBuilder().withName("A").withCertificates(certList).build();
+        new AddCommand(person1).execute(model);
+        new AddCommand(person2).execute(model);
+
+        // edit certificate of person 2, not person 1
+        new CertEditCommand(Index.fromOneBased(2),
+                new Certificate(new CertName("OSCP")),
+                Optional.of(new CertName("OSCP2")),
+                Optional.empty())
+                .execute(model);
+
+        assertEquals(model.getFilteredPersonList().get(0), person1);
+        ArrayList<Certificate> expectedCertList = new ArrayList<Certificate>() {
+            {
+                add(new Certificate(new CertName("OSCP2")));
+            }
+        };
+        Person expectedPerson2 = new PersonBuilder().withName("A")
+                .withCertificates(expectedCertList)
+                .build();
+        assertEquals(model.getFilteredPersonList().get(1), expectedPerson2);
+    }
+
+    @Test
     public void equals() {
         Certificate cert1 = new Certificate(new CertName("cert1"));
         Certificate cert2 = new Certificate(new CertName("cert2"));

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -27,6 +27,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.TagColour;
 import seedu.address.model.tag.TagSet;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
@@ -233,6 +234,22 @@ public class TagCommandTest {
 
         assertCommandFailure(tagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
+    }
+
+    @Test
+    public void execute_tagIndexSpecifiedPerson() throws Exception {
+        Model model = new ModelManager(new AddressBook(), new UserPrefs());
+        Person person1 = new PersonBuilder().withName("a").build();
+        Person person2 = new PersonBuilder().withName("A").build();
+        new AddCommand(person1).execute(model);
+        new AddCommand(person2).execute(model);
+
+        new TagCommand(Index.fromOneBased(2), Set.of(new Tag("test")), true)
+                .execute(model);
+
+        Person expectedPerson2 = new PersonBuilder().withName("A").withTags("test").build();
+        assertEquals(model.getFilteredPersonList().get(0), person1);
+        assertEquals(model.getFilteredPersonList().get(1), expectedPerson2);
     }
 
     @Test


### PR DESCRIPTION
There was a bug where if we have two persons with the same name, editing the second one would actually edit the first one. This is due to the way setPerson was implemented.

Let's:
* fix bug for cert-add, cert-edit, cert-del, tag
* update test cases to test for this bug